### PR TITLE
Avoid serializing 'undefined' values

### DIFF
--- a/src/util/router.ts
+++ b/src/util/router.ts
@@ -94,7 +94,7 @@ export function Router<ROUTES extends Record<string, RouteDefinitionValue<{}>>>(
       encodeURIComponent(params[p.substring(1)])
     )
     const query = Object.keys(params)
-      .filter((p) => !routeToLink.keys.includes(p))
+      .filter((p) => !routeToLink.keys.includes(p) && params[p] !== undefined)
       .map((p) => `${p}=${encodeURIComponent(params[p])}`)
       .join('&')
     return path + (query.length ? `?${query}` : '')


### PR DESCRIPTION
Issue: when using `push` or `replace`, any present field in `params` that has an `undefined` value will be serialized to `'undefined'` instead of being omitted.

Fix: filter out `undefined` values before serializing `params` properties.